### PR TITLE
Make tax_class_id nullable like its backing field

### DIFF
--- a/Magento.RestApi/Models/Product.cs
+++ b/Magento.RestApi/Models/Product.cs
@@ -281,7 +281,7 @@ namespace Magento.RestApi.Models
         /// Product tax class. Can have the following values: 0 - None, 2 - taxable Goods, 4 - Shipping, etc., depending on created tax classes.
         /// </summary>
         /// <remarks>required</remarks>
-        public int tax_class_id
+        public int? tax_class_id
         {
             get { return GetValue(x => x.tax_class_id); }
             set { SetValue(x => x.tax_class_id, value); }


### PR DESCRIPTION
Kept getting an exception pulling down some products, and it turned out to be this.