### PR TITLE
Reusable Access Tokens

### DIFF
--- a/Magento.RestApi/MagentoApi.cs
+++ b/Magento.RestApi/MagentoApi.cs
@@ -48,6 +48,15 @@ namespace Magento.RestApi
                 return _client;
             }
         }
+        
+        /// <summary>
+        /// allow read access to token key for later calls
+        /// </summary>
+        public String AccessTokenKey => this._accessTokenKey;
+        /// <summary>
+        /// allow read access to token secret for later calls
+        /// </summary>
+        public String AccessTokenSecret => this._accessTokenSecret;
 
         /// <summary>
         /// Initializes the client, setting url, consumerkey and consumersecret and adding default request headers and handlers

--- a/Magento.RestApi/MagentoApiManager.cs
+++ b/Magento.RestApi/MagentoApiManager.cs
@@ -1,0 +1,73 @@
+﻿namespace Magento.RestApi
+{
+    public class MagentoApiManager
+    {
+        public Models.ApiSettings Settings { get; private set; }
+        public MagentoApi ApiClient { get; private set; }
+        public bool AccessTokensChanges { get; private set; }
+
+        public MagentoApiManager(Models.ApiSettings settings)
+        {
+            this.Settings = settings;
+            this.Initialize();
+        }
+        /// <summary>
+        /// constructor to manually pass in all settings individually
+        /// </summary>
+        /// <param name="url"></param>
+        /// <param name="userName"></param>
+        /// <param name="password"></param>
+        /// <param name="consumerKey"></param>
+        /// <param name="consumerSecret"></param>
+        /// <param name="accessKey"></param>
+        /// <param name="accessSecret"></param>
+        /// <param name="healthcheckItemId"></param>
+        public MagentoApiManager(string url, string userName, string password, string consumerKey, string consumerSecret, string accessKey, string accessSecret, int healthcheckItemId)
+        {
+            this.Settings = new Models.ApiSettings
+            {
+                Url = url,
+                UserName = userName,
+                Password = password,
+                ConsumerKey = consumerKey,
+                ConsumerSecret = consumerSecret,
+                AccessKey = accessKey,
+                AccessSecret = accessSecret,
+                HealthcheckItemId = healthcheckItemId
+            };
+        }
+
+        private void Initialize()
+        {
+            this.ApiClient = new MagentoApi();
+            this.ApiClient.Initialize(this.Settings.Url, this.Settings.ConsumerKey, this.Settings.ConsumerSecret)
+                .SetAccessToken(this.Settings.AccessKey, this.Settings.AccessSecret);
+
+            if (this.TestConnection()) return;
+
+            this.Authenticate();
+        }
+
+        private bool Authenticate()
+        {
+            this.ApiClient.AuthenticateAdmin(this.Settings.UserName, this.Settings.Password);
+
+            this.Settings.AccessKey = this.ApiClient.AccessTokenKey;
+            this.Settings.AccessSecret = this.ApiClient.AccessTokenSecret;
+
+            this.AccessTokensChanges = true;
+
+            return this.TestConnection();
+        }
+
+        
+
+        public bool TestConnection()
+        {
+            var resultTask = this.ApiClient.GetWebsitesForProduct(this.Settings.HealthcheckItemId);
+            resultTask.Wait();
+
+            return !resultTask.Result.HasErrors;
+        }
+    }
+}

--- a/Magento.RestApi/Models/ApiSettings.cs
+++ b/Magento.RestApi/Models/ApiSettings.cs
@@ -1,0 +1,42 @@
+﻿namespace Magento.RestApi.Models
+{
+    /// <summary>
+    /// structure for magento api Settings
+    /// </summary>
+    public class ApiSettings
+    {
+        /// <summary>
+        /// key acquired from oAuth flow
+        /// </summary>
+        public string AccessKey { get; set; }
+        /// <summary>
+        /// secret acquired from oAuth flow
+        /// </summary>
+        public string AccessSecret { get; set; }
+        /// <summary>
+        /// key from user in Magento
+        /// </summary>
+        public string ConsumerKey { get; set; }
+        /// <summary>
+        /// secret from user in Magento
+        /// </summary>
+        public string ConsumerSecret { get; set; }
+        /// <summary>
+        /// Magento user password for admin authentication
+        /// </summary>
+        public string Password { get; set; }
+        /// <summary>
+        /// Magento user name for admin authentication
+        /// </summary>
+        public string UserName { get; set; }
+        /// <summary>
+        /// Magento base URL
+        /// </summary>
+        public string Url { get; set; }
+        /// <summary>
+        /// item id used for healthcheck
+        /// </summary>
+        public int HealthcheckItemId { get; set; }
+        
+    }
+}


### PR DESCRIPTION
This change would allow for authentication reusage by exposing the token key and secret.  According to http://devdocs.magento.com/guides/m1x/api/rest/authentication/oauth_authentication.html "Access tokens are long-lived and will not expire unless the user revokes access to the application." So we may only need to get them the first time and persist them somewhere for later calls. Then we can to go through the whole slower process if we get a HTTP:401 with token_revoked.