### PR TITLE
fix lock statement in AuthenticateAdmin

### DIFF
--- a/Magento.RestApi/MagentoApi.cs
+++ b/Magento.RestApi/MagentoApi.cs
@@ -35,6 +35,7 @@ namespace Magento.RestApi
     
         private JsonSerializer _jsonSerializer;
         private RestClient _client;
+        private object _lock = new object();
 
         private RestClient Client
         {
@@ -149,7 +150,7 @@ namespace Magento.RestApi
         /// <returns>this, for fluent configuration</returns>
         public IMagentoApi AuthenticateAdmin(string userName, string password)
         {
-            lock (_client)
+            lock (_lock)
             {
                 try
                 {


### PR DESCRIPTION
use separate lock object since `_client` is replaced in `InitializeRestClient` and does not avoid multiple calls to `AuthenticateAdmin` which can result in an invalid state where the `_client` has duplicated header values.

Invalid (values duplicated):
```
Authorization: OAuth oauth_consumer_key="b621260b36c26da00c94ff8036d9a822",oauth_nonce="ax8g5f4eij6x6q01",oauth_signature="ZARVQXvFG4zQD9FXAYuh4nPkf%2BY%3D",oauth_signature_method="HMAC-SHA1",oauth_timestamp="1468840392",oauth_token="e1598df63e74e6512951c0f72e246ab6",oauth_version="1.0", OAuth oauth_consumer_key="b621260b36c26da00c94ff8036d9a822",oauth_nonce="rjxcgxphybsnyoqb",oauth_signature="FhGupD2BonuMex%2F2IJn7Q1pSQm0%3D",oauth_signature_method="HMAC-SHA1",oauth_timestamp="1468840393",oauth_token="4279db649a1264f5e59a6971a27e3edc",oauth_version="1.0"
```

Valid:
```
Authorization: OAuth oauth_consumer_key="b621260b36c26da00c94ff8036d9a822",oauth_nonce="jo5cpv8k3dzwek8i",oauth_signature="tfryOWLcw9P%2FNTOZORk%2BhJn%2BRh0%3D",oauth_signature_method="HMAC-SHA1",oauth_timestamp="1468841078",oauth_token="4279db649a1264f5e59a6971a27e3edc",oauth_version="1.0"
```